### PR TITLE
games-emulation/bsnes-libretro: Add support for opengl driver

### DIFF
--- a/games-emulation/bsnes-libretro/bsnes-libretro-1.0_pre20170124.ebuild
+++ b/games-emulation/bsnes-libretro/bsnes-libretro-1.0_pre20170124.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="amd64 x86"
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="profile_accuracy +profile_balanced profile_performance"
+IUSE="profile_accuracy +profile_balanced profile_performance opengl"
 
 REQUIRED_USE="|| ( profile_accuracy profile_balanced profile_performance )"
 
@@ -32,6 +32,11 @@ src_unpack() {
 	libretro-core_src_unpack
 }
 
+src_prepare() {
+	# Enable OpenGL driver
+	use opengl && sed -e '/^# platform/s/$/\nflags += -DVIDEO_GLX\n/' -i Makefile
+	libretro-core_src_prepare
+}
 src_compile() {
 	myemakeargs=( "ui=target-libretro" )
 	if use profile_balanced; then

--- a/games-emulation/bsnes-libretro/bsnes-libretro-1.0_pre20170204.ebuild
+++ b/games-emulation/bsnes-libretro/bsnes-libretro-1.0_pre20170204.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="~amd64 ~x86"
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="profile_accuracy +profile_balanced profile_performance"
+IUSE="profile_accuracy +profile_balanced profile_performance opengl"
 
 REQUIRED_USE="|| ( profile_accuracy profile_balanced profile_performance )"
 
@@ -30,6 +30,12 @@ src_unpack() {
 	use profile_balanced && LIBRETRO_CORE_NAME+=( "${PN%-libretro}"_balanced )
 	use profile_performance && LIBRETRO_CORE_NAME+=( "${PN%-libretro}"_performance )
 	libretro-core_src_unpack
+}
+
+src_prepare() {
+	# Enable OpenGL driver
+	use opengl && sed -e '/^# platform/s/$/\nflags += -DVIDEO_GLX\n/' -i Makefile
+	libretro-core_src_prepare
 }
 
 src_compile() {

--- a/games-emulation/bsnes-libretro/bsnes-libretro-9999-r2.ebuild
+++ b/games-emulation/bsnes-libretro/bsnes-libretro-9999-r2.ebuild
@@ -12,7 +12,7 @@ KEYWORDS=""
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="profile_accuracy +profile_balanced profile_performance"
+IUSE="profile_accuracy +profile_balanced profile_performance opengl"
 
 REQUIRED_USE="|| ( profile_accuracy profile_balanced profile_performance )"
 
@@ -29,6 +29,12 @@ src_unpack() {
 	use profile_balanced && LIBRETRO_CORE_NAME+=( "${PN%-libretro}"_balanced )
 	use profile_performance && LIBRETRO_CORE_NAME+=( "${PN%-libretro}"_performance )
 	libretro-core_src_unpack
+}
+
+src_prepare() {
+	# Enable OpenGL driver
+	use opengl && sed -e '/^# platform/s/$/\nflags += -DVIDEO_GLX\n/' -i Makefile
+	libretro-core_src_prepare
 }
 
 src_compile() {


### PR DESCRIPTION
By default bsnes-libretro uses the "safe" software driver,
add a USE flag to enable the GLX OpenGL driver.  There is
also an SDL driver, maybe enable it too?