### PR TITLE
games-emulation/retroarch - support JACK2

### DIFF
--- a/games-emulation/retroarch/retroarch-1.3.4-r3.ebuild
+++ b/games-emulation/retroarch/retroarch-1.3.4-r3.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 	cores? ( games-emulation/libretro-meta:0= )
 	database? ( games-emulation/libretro-database:0= )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0= )
+	jack? ( virtual/jack:= )
 	joypad_autoconfig? ( games-emulation/retroarch-joypad-autoconfig:0= )
 	libass? ( media-libs/libass:0= )
 	libusb? ( virtual/libusb:1= )

--- a/games-emulation/retroarch/retroarch-1.3.6-r3.ebuild
+++ b/games-emulation/retroarch/retroarch-1.3.6-r3.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	database? ( games-emulation/libretro-database:0= )
 	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0= )
+	jack? ( virtual/jack:= )
 	joypad_autoconfig? ( games-emulation/retroarch-joypad-autoconfig:0= )
 	libass? ( media-libs/libass:0= )
 	libusb? ( virtual/libusb:1= )

--- a/games-emulation/retroarch/retroarch-1.4.0.ebuild
+++ b/games-emulation/retroarch/retroarch-1.4.0.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	database? ( games-emulation/libretro-database:0= )
 	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0= )
+	jack? ( virtual/jack:= )
 	joypad_autoconfig? ( games-emulation/retroarch-joypad-autoconfig:0= )
 	libass? ( media-libs/libass:0= )
 	libusb? ( virtual/libusb:1= )

--- a/games-emulation/retroarch/retroarch-1.4.1.ebuild
+++ b/games-emulation/retroarch/retroarch-1.4.1.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	database? ( games-emulation/libretro-database:0= )
 	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0= )
+	jack? ( virtual/jack:= )
 	joypad_autoconfig? ( games-emulation/retroarch-joypad-autoconfig:0= )
 	libass? ( media-libs/libass:0= )
 	libusb? ( virtual/libusb:1= )

--- a/games-emulation/retroarch/retroarch-1.5.0.ebuild
+++ b/games-emulation/retroarch/retroarch-1.5.0.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	database? ( games-emulation/libretro-database:0= )
 	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0= )
+	jack? ( virtual/jack:= )
 	joypad_autoconfig? ( games-emulation/retroarch-joypad-autoconfig:0= )
 	libass? ( media-libs/libass:0= )
 	libusb? ( virtual/libusb:1= )

--- a/games-emulation/retroarch/retroarch-1.6.0-r2.ebuild
+++ b/games-emulation/retroarch/retroarch-1.6.0-r2.ebuild
@@ -61,7 +61,7 @@ RDEPEND="
 	database? ( games-emulation/libretro-database:0= )
 	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0= )
+	jack? ( virtual/jack:= )
 	joypad_autoconfig? ( games-emulation/retroarch-joypad-autoconfig:0= )
 	libass? ( media-libs/libass:0= )
 	libusb? ( virtual/libusb:1= )

--- a/games-emulation/retroarch/retroarch-1.6.0.ebuild
+++ b/games-emulation/retroarch/retroarch-1.6.0.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	database? ( games-emulation/libretro-database:0= )
 	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0= )
+	jack? ( virtual/jack:= )
 	joypad_autoconfig? ( games-emulation/retroarch-joypad-autoconfig:0= )
 	libass? ( media-libs/libass:0= )
 	libusb? ( virtual/libusb:1= )

--- a/games-emulation/retroarch/retroarch-9999-r3.ebuild
+++ b/games-emulation/retroarch/retroarch-9999-r3.ebuild
@@ -57,7 +57,7 @@ RDEPEND="
 	database? ( games-emulation/libretro-database:0= )
 	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
-	jack? ( >=media-sound/jack-audio-connection-kit-0.120.1:0= )
+	jack? ( virtual/jack:= )
 	joypad_autoconfig? ( games-emulation/retroarch-joypad-autoconfig:0= )
 	libass? ( media-libs/libass:0= )
 	libusb? ( virtual/libusb:1= )


### PR DESCRIPTION
Depending on "virtual/jack" allows both the upstream "media-sound/jack2" and my "media-sound/jack-audio-connection-kit:2" copy (previously blocked by depending on slot 0). Tested and working.