### PR TITLE
Make qtstyleplugins rebuild with qt version change

### DIFF
--- a/x11-themes/qtstyleplugins/qtstyleplugins-1.0_pre20170311.ebuild
+++ b/x11-themes/qtstyleplugins/qtstyleplugins-1.0_pre20170311.ebuild
@@ -16,8 +16,8 @@ KEYWORDS="~x86 ~amd64"
 
 DEPEND="
 	x11-libs/gtk+:2
-	dev-qt/qtgui:5
-	dev-qt/qtdbus:5
+	dev-qt/qtgui:5=
+	dev-qt/qtdbus:5=
 	x11-libs/libX11"
 RDEPEND="${DEPEND}"
 

--- a/x11-themes/qtstyleplugins/qtstyleplugins-9999.ebuild
+++ b/x11-themes/qtstyleplugins/qtstyleplugins-9999.ebuild
@@ -15,8 +15,8 @@ KEYWORDS=""
 
 DEPEND="
 	x11-libs/gtk+:2
-	dev-qt/qtgui:5
-	dev-qt/qtdbus:5
+	dev-qt/qtgui:5=
+	dev-qt/qtdbus:5=
 	x11-libs/libX11"
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Currently qtstyleplugins break for me every time qt version bumps, even minor.
This commit makes them be rebuilt automatically on every version change, which is nicer.