### PR TITLE
x11-themes/papirus-icon-theme: Added GTK+ icon cache update

### DIFF
--- a/x11-themes/papirus-icon-theme/papirus-icon-theme-9999.ebuild
+++ b/x11-themes/papirus-icon-theme/papirus-icon-theme-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit git-r3
+inherit git-r3 gnome2-utils
 
 DESCRIPTION="Papirus icon theme for GTK and KDE"
 HOMEPAGE="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme"
@@ -17,3 +17,11 @@ IUSE=""
 
 DEPEND=""
 RDEPEND="${DEPEND}"
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+}


### PR DESCRIPTION
Packages that install icons need to call `gnome2_icon_cache_update`.